### PR TITLE
move metric memory to python

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,7 +14,6 @@ services:
   service-indexer: "$SEARCH_INDEXER_METRICS_PATH"
 scrape_interval: 30
 token: "sha256~..."
-window_size: 5
 z_score_threshold: 2.0
 services_context:
   search-api:


### PR DESCRIPTION
store history of metrics in the anomaly detection service instead of Go. this will let us do more intelligent causal analysis like providing trend info alongside the anomaly information to the agent